### PR TITLE
fix: resolve TypeScript compilation errors

### DIFF
--- a/src/cli/utils/workflow-validator.ts
+++ b/src/cli/utils/workflow-validator.ts
@@ -39,7 +39,7 @@ class WorkflowValidator {
     // Try to load from cache first
     try {
       const cached = await readFile(SCHEMA_CACHE_PATH, 'utf-8');
-      this.schema = JSON.parse(cached);
+      this.schema = JSON.parse(cached) as object;
       return this.schema;
     } catch {
       // Cache miss or read error, fetch from network
@@ -51,7 +51,7 @@ class WorkflowValidator {
       throw new Error(`Failed to fetch workflow schema: ${response.statusText}`);
     }
 
-    this.schema = await response.json();
+    this.schema = (await response.json()) as object;
 
     // Cache for future use
     try {

--- a/src/generator/index.test.ts
+++ b/src/generator/index.test.ts
@@ -106,7 +106,9 @@ describe('WorkflowGenerator', () => {
       const workflow = yaml.load(result) as ParsedWorkflow;
       // Find the "Add agent instructions" step
       const steps = workflow.jobs['claude-agent'].steps;
-      const instructionsStep = steps.find((step: WorkflowStep) => step.name === 'Add agent instructions');
+      const instructionsStep = steps.find(
+        (step: WorkflowStep) => step.name === 'Add agent instructions'
+      );
 
       expect(instructionsStep).toBeDefined();
       expect(instructionsStep?.run).toContain('Test Instructions');
@@ -214,7 +216,9 @@ describe('WorkflowGenerator', () => {
       const result = generator.generate(agent);
       const workflow = yaml.load(result) as ParsedWorkflow;
       const steps = workflow.jobs['claude-agent'].steps;
-      const instructionsStep = steps.find((step: WorkflowStep) => step.name === 'Add agent instructions');
+      const instructionsStep = steps.find(
+        (step: WorkflowStep) => step.name === 'Add agent instructions'
+      );
 
       expect(instructionsStep).toBeDefined();
       expect(instructionsStep?.run).toContain('\\`code\\`');
@@ -265,7 +269,9 @@ describe('WorkflowGenerator', () => {
         const result = generator.generate(agent);
         const workflow = yaml.load(result) as ParsedWorkflow;
         const steps = workflow.jobs['pre-flight'].steps;
-        const userStep = steps.find((step: WorkflowStep) => step.name === 'Check user authorization');
+        const userStep = steps.find(
+          (step: WorkflowStep) => step.name === 'Check user authorization'
+        );
 
         expect(userStep).toBeDefined();
         expect(userStep?.run).toContain('github.actor');
@@ -317,7 +323,9 @@ describe('WorkflowGenerator', () => {
         const result = generator.generate(agent);
         const workflow = yaml.load(result) as ParsedWorkflow;
         const steps = workflow.jobs['pre-flight'].steps;
-        const userStep = steps.find((step: WorkflowStep) => step.name === 'Check user authorization');
+        const userStep = steps.find(
+          (step: WorkflowStep) => step.name === 'Check user authorization'
+        );
 
         expect(userStep).toBeDefined();
         expect(userStep?.run).toContain('user1 user2');
@@ -368,7 +376,9 @@ describe('WorkflowGenerator', () => {
         const result = generator.generate(agent);
         const workflow = yaml.load(result) as ParsedWorkflow;
         const steps = workflow.jobs['claude-agent'].steps;
-        const skillsStep = steps.find((step: WorkflowStep) => step.name === 'Create Claude skills file');
+        const skillsStep = steps.find(
+          (step: WorkflowStep) => step.name === 'Create Claude skills file'
+        );
 
         expect(skillsStep).toBeUndefined();
       });
@@ -386,7 +396,9 @@ describe('WorkflowGenerator', () => {
         const result = generator.generate(agent);
         const workflow = yaml.load(result) as ParsedWorkflow;
         const steps = workflow.jobs['claude-agent'].steps;
-        const skillsStep = steps.find((step: WorkflowStep) => step.name === 'Create Claude skills file');
+        const skillsStep = steps.find(
+          (step: WorkflowStep) => step.name === 'Create Claude skills file'
+        );
 
         expect(skillsStep).toBeDefined();
         expect(skillsStep?.run).toContain('CLAUDE.md');
@@ -406,7 +418,9 @@ describe('WorkflowGenerator', () => {
         const result = generator.generate(agent);
         const workflow = yaml.load(result) as ParsedWorkflow;
         const steps = workflow.jobs['claude-agent'].steps;
-        const outputsStep = steps.find((step: WorkflowStep) => step.name === 'Create outputs directory');
+        const outputsStep = steps.find(
+          (step: WorkflowStep) => step.name === 'Create outputs directory'
+        );
 
         expect(outputsStep).toBeDefined();
         expect(outputsStep?.run).toContain('/tmp/outputs');

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -25,7 +25,7 @@ interface GitHubWorkflow {
 
 export class WorkflowGenerator {
   generate(agent: AgentDefinition): string {
-    const workflow: GitHubWorkflow = {
+    const workflow: Partial<GitHubWorkflow> & { name: string; on: TriggerConfig } = {
       name: agent.name,
       on: this.generateTriggers(agent),
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,10 +115,11 @@ export interface WorkflowStep {
   name?: string;
   id?: string;
   uses?: string;
-  with?: Record<string, string>;
+  with?: Record<string, string | boolean>;
   run?: string;
   env?: Record<string, string>;
   if?: string;
+  'continue-on-error'?: boolean;
 }
 
 // Input Configuration Types


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation errors that were causing CI failures
- Add explicit type assertions in workflow-validator.ts for JSON parsing
- Use Partial<GitHubWorkflow> for initial workflow object in generator
- Add 'continue-on-error' property to WorkflowStep interface
- Allow boolean values in WorkflowStep.with for 'merge-multiple' option

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 165 tests pass (`bun test`)
- [x] ESLint passes (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)