### PR TITLE
fix: use concatenated template for issue/PR number detection

### DIFF
--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -641,6 +641,9 @@ fi
       repository: '${{ github.repository }}',
       issueNumber: '${{ github.event.issue.number }}',
       prNumber: '${{ github.event.pull_request.number }}',
+      // Concatenate both template strings - at workflow runtime, only one will be non-empty
+      // This allows the same workflow to work for both issue and PR events
+      issueOrPrNumber: '${{ github.event.issue.number }}${{ github.event.pull_request.number }}',
       allowedPaths: agent.allowed_paths,
     };
   }
@@ -823,7 +826,7 @@ if [ -d "/tmp/all-validation-errors" ] && [ "$(ls -A /tmp/all-validation-errors 
   done
 
   # Post comment if we have issue/PR number
-  ISSUE_OR_PR_NUMBER="${runtime.issueNumber || runtime.prNumber}"
+  ISSUE_OR_PR_NUMBER="${runtime.issueOrPrNumber}"
   if [ -n "$ISSUE_OR_PR_NUMBER" ]; then
     echo -e "$ERROR_MSG" | gh api "repos/${runtime.repository}/issues/$ISSUE_OR_PR_NUMBER/comments" \\
       -X POST \\

--- a/src/generator/outputs/add-comment.ts
+++ b/src/generator/outputs/add-comment.ts
@@ -48,7 +48,7 @@ Or for multiple comments:
   }
 
   generateValidationScript(config: OutputConfig, runtime: RuntimeContext): string {
-    const issueOrPrNumber = runtime.issueNumber || runtime.prNumber;
+    const issueOrPrNumber = runtime.issueOrPrNumber;
     const maxConstraint = config.max;
 
     return `

--- a/src/generator/outputs/add-label.ts
+++ b/src/generator/outputs/add-label.ts
@@ -61,7 +61,7 @@ Create \`/tmp/outputs/add-label.json\` with:
   }
 
   generateValidationScript(_config: OutputConfig, runtime: RuntimeContext): string {
-    const issueOrPrNumber = runtime.issueNumber || runtime.prNumber;
+    const issueOrPrNumber = runtime.issueOrPrNumber;
 
     return `
 # Validate and execute add-label output(s)

--- a/src/generator/outputs/base.ts
+++ b/src/generator/outputs/base.ts
@@ -10,6 +10,12 @@ export interface RuntimeContext {
   issueNumber?: string;
   /** Pull request number if triggered by PR event */
   prNumber?: string;
+  /**
+   * Combined issue or PR number for use in bash scripts.
+   * Uses concatenation of both template strings so the correct one
+   * is used at workflow runtime (whichever is non-empty).
+   */
+  issueOrPrNumber: string;
   /** Allowed paths glob patterns for file operations */
   allowedPaths?: string[];
 }

--- a/src/generator/outputs/remove-label.ts
+++ b/src/generator/outputs/remove-label.ts
@@ -57,7 +57,7 @@ Create \`/tmp/outputs/remove-label.json\` with:
   }
 
   generateValidationScript(_config: OutputConfig, runtime: RuntimeContext): string {
-    const issueOrPrNumber = runtime.issueNumber || runtime.prNumber;
+    const issueOrPrNumber = runtime.issueOrPrNumber;
 
     return `
 # Validate and execute remove-label output


### PR DESCRIPTION
## Summary

- Fixes issue/PR number detection in output handlers for pull_request events
- Adds missing labels required by the PR review agent

## Problem

The output handlers were using JavaScript's `||` operator at generator time to pick between `issueNumber` and `prNumber` template strings:

```typescript
const issueOrPrNumber = runtime.issueNumber || runtime.prNumber;
```

Since both strings are non-empty (they contain GitHub Actions template syntax like `${{ github.event.issue.number }}`), the `||` always picked `issueNumber`. At workflow runtime, this evaluates to an empty string for `pull_request` events, causing validation errors:

```
- **add-comment**: No issue or PR number available
- **add-label**: No issue or PR number available
```

## Solution

Added `issueOrPrNumber` to `RuntimeContext` that concatenates both template strings:

```typescript
issueOrPrNumber: '${{ github.event.issue.number }}${{ github.event.pull_request.number }}'
```

At workflow runtime, only one template will evaluate to a non-empty value, giving us the correct number regardless of whether the trigger is an issue or PR event.

## Changes

- Added `issueOrPrNumber` field to `RuntimeContext` interface
- Updated `createRuntimeContext` to populate the new field
- Updated all output handlers (`add-comment`, `add-label`, `remove-label`) to use `runtime.issueOrPrNumber`
- Updated `generateReportResultsJob` to use the new field

## Labels Created

Also created the missing labels that the PR review agent references:
- `needs-tests` - PR needs additional tests
- `breaking-change` - This change may break existing functionality
- `needs-docs` - Documentation updates needed
- `ready-for-review` - Ready for human review

## Test plan

- [x] All unit tests pass
- [x] Build succeeds
- [x] Lint passes
- [ ] Verify next PR triggers successful workflow execution

🤖 Generated with [Claude Code](https://claude.ai/code)