### PR TITLE
docs: improve cross-references and navigation

### DIFF
--- a/docs/src/content/docs/cli/compile.md
+++ b/docs/src/content/docs/cli/compile.md
@@ -81,4 +81,14 @@ The compiled workflow includes:
 
 - [Validate](../validate/) agents before compiling
 - [List](../list/) all agents
-- Learn about [Agent Definition](../../guide/agent-definition/)
+- Learn about [Agent Definition](/gh-claude/guide/agent-definition/)
+
+## See It In Action
+
+- [Issue Triage Example](/gh-claude/examples/issue-triage/) - Complete agent workflow
+- [Daily Summary Example](/gh-claude/examples/daily-summary/) - Scheduled agent
+
+## See Also
+
+- [Testing Strategies](/gh-claude/guide/testing-strategies/) - Safe development workflow
+- [Troubleshooting](/gh-claude/guide/troubleshooting/) - Common issues

--- a/docs/src/content/docs/cli/init.md
+++ b/docs/src/content/docs/cli/init.md
@@ -74,7 +74,17 @@ With `--examples`, creates starter agent templates:
 
 After initialization:
 
-1. Configure your [Anthropic API key](../../getting-started/installation/#setting-up-api-key)
+1. Configure authentication with [setup-token](../setup-token/)
 2. Review or customize example agents
 3. [Compile](../compile/) agents to workflows
 4. Commit and push changes
+
+## See It In Action
+
+- [Issue Triage Example](/gh-claude/examples/issue-triage/) - Complete triage agent
+- [PR Review Example](/gh-claude/examples/pr-review/) - Code review agent
+
+## See Also
+
+- [Quick Start](/gh-claude/getting-started/quick-start/) - Full getting started guide
+- [Agent Definition](/gh-claude/guide/agent-definition/) - How to write agents

--- a/docs/src/content/docs/cli/validate.md
+++ b/docs/src/content/docs/cli/validate.md
@@ -121,4 +121,10 @@ jobs:
 ## Next Steps
 
 - [Compile](../compile/) validated agents
-- Review [Agent Definition](../../guide/agent-definition/)
+- Review [Agent Definition](/gh-claude/guide/agent-definition/)
+
+## See Also
+
+- [Testing Strategies](/gh-claude/guide/testing-strategies/) - Safe development workflow
+- [Troubleshooting](/gh-claude/guide/troubleshooting/) - Common validation errors
+- [Quick Reference](/gh-claude/reference/quick-reference/) - Valid field values

--- a/docs/src/content/docs/guide/agent-definition.md
+++ b/docs/src/content/docs/guide/agent-definition.md
@@ -258,6 +258,12 @@ Keep the tone friendly and professional!
 
 ## Next Steps
 
-- Learn about [Triggers](../../triggers/)
-- Explore [Outputs](../outputs/)
-- Review [Examples](../../examples/issue-triage/)
+- [Triggers](/gh-claude/triggers/) - When your agent runs
+- [Outputs](/gh-claude/guide/outputs/) - What your agent can do
+- [Examples](/gh-claude/examples/) - See complete agents
+
+## See Also
+
+- [Quick Reference](/gh-claude/reference/quick-reference/) - All frontmatter fields
+- [Permissions](/gh-claude/guide/permissions/) - GitHub permission configuration
+- [Security Best Practices](/gh-claude/guide/security-best-practices/) - Secure agent configuration

--- a/docs/src/content/docs/guide/permissions.md
+++ b/docs/src/content/docs/guide/permissions.md
@@ -84,7 +84,9 @@ outputs:
   add-label: true
 ```
 
-## Next Steps
+## See Also
 
-- Learn about [Outputs](../outputs/)
-- Review [Security](../../reference/security/)
+- [Outputs Overview](/gh-claude/guide/outputs/) - Actions your agent can take
+- [Security Best Practices](/gh-claude/guide/security-best-practices/) - Secure permission patterns
+- [Agent Definition](/gh-claude/guide/agent-definition/) - Complete agent configuration
+- [Quick Reference](/gh-claude/reference/quick-reference/) - Permission lookup table

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -162,3 +162,10 @@ security:
   require_outputs: false
   require_permissions: false
 ```
+
+## See Also
+
+- [Authentication](/gh-claude/guide/authentication/) - API key setup
+- [Quick Reference](/gh-claude/reference/quick-reference/) - All configuration options
+- [Agent Definition](/gh-claude/guide/agent-definition/) - Per-agent configuration
+- [Cost Estimation](/gh-claude/guide/cost-estimation/) - Model cost comparison


### PR DESCRIPTION
## Summary
- Add 'See Also' sections to pages missing them (permissions.md, agent-definition.md, configuration.md)
- Add 'See It In Action' sections to CLI pages linking to examples (init.md, compile.md)
- Add 'See Also' sections to CLI pages (init.md, compile.md, validate.md)
- Improve links in 'Next Steps' sections with consistent absolute paths

## Test plan
- [x] Docs build successfully (61 pages)
- [x] All new links verified

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)