### PR TITLE
docs: consistency pass - fix links and standardize formats

### DIFF
--- a/docs/src/content/docs/outputs/comments.md
+++ b/docs/src/content/docs/outputs/comments.md
@@ -265,12 +265,12 @@ If your agent posts more comments than expected:
 
 ## Related Outputs
 
-- [Labels (add-label, remove-label)](./labels.md) - Pair with comments for issue management
-- [Issues (create-issue, close-issue)](./issues.md) - For creating new issues
-- [Pull Requests (create-pr, close-pr)](./pull-requests.md) - For PR management
+- [Labels (add-label, remove-label)](./labels/) - Pair with comments for issue management
+- [Issues (create-issue, close-issue)](./issues/) - For creating new issues
+- [Pull Requests (create-pr, close-pr)](./pull-requests/) - For PR management
 
 ## Next Steps
 
-- Learn about [Permissions](../permissions/)
-- Explore [Labels output](./labels.md)
+- Learn about [Permissions](../../guide/permissions/)
+- Explore [Labels output](./labels/)
 - Review [Security Best Practices](../../reference/security/)

--- a/docs/src/content/docs/outputs/discussions.md
+++ b/docs/src/content/docs/outputs/discussions.md
@@ -482,12 +482,12 @@ Verify the category:
 
 ## Related Outputs
 
-- [Comments (add-comment)](./comments.md) - For direct engagement
-- [Issues (create-issue, close-issue)](./issues.md) - For bug tracking
-- [Pull Requests (create-pr, close-pr)](./pull-requests.md) - For code changes
+- [Comments (add-comment)](./comments/) - For direct engagement
+- [Issues (create-issue, close-issue)](./issues/) - For bug tracking
+- [Pull Requests (create-pr, close-pr)](./pull-requests/) - For code changes
 
 ## Next Steps
 
-- Learn about [Permissions](../permissions/)
+- Learn about [Permissions](../../guide/permissions/)
 - Explore [Triggers](../../triggers/) to control when discussions are created
 - Review [Security Best Practices](../../reference/security/)

--- a/docs/src/content/docs/outputs/files.md
+++ b/docs/src/content/docs/outputs/files.md
@@ -650,12 +650,12 @@ If files are being modified incorrectly:
 
 ## Related Outputs
 
-- [Pull Requests (create-pr, close-pr)](./pull-requests.md) - Alternative for code review
-- [Comments (add-comment)](./comments.md) - For explaining changes
-- [Issues (create-issue, close-issue)](./issues.md) - For coordinating changes
+- [Pull Requests (create-pr, close-pr)](./pull-requests/) - Alternative for code review
+- [Comments (add-comment)](./comments/) - For explaining changes
+- [Issues (create-issue, close-issue)](./issues/) - For coordinating changes
 
 ## Next Steps
 
-- Learn about [Permissions](../permissions/)
+- Learn about [Permissions](../../guide/permissions/)
 - Review [Security Best Practices](../../reference/security/)
 - Explore [Examples](../../examples/issue-triage/)

--- a/docs/src/content/docs/outputs/index.md
+++ b/docs/src/content/docs/outputs/index.md
@@ -43,30 +43,30 @@ permissions:
 ## Available Output Types
 
 ### Comments
-- [**add-comment**](./comments.md) - Post comments on issues or pull requests
+- [**add-comment**](./comments/) - Post comments on issues or pull requests
   - Configuration: `max` (maximum number of comments)
 
 ### Labels
-- [**add-label**](./labels.md) - Add labels to issues or pull requests
-- [**remove-label**](./labels.md) - Remove labels from issues or pull requests
+- [**add-label**](./labels/) - Add labels to issues or pull requests
+- [**remove-label**](./labels/) - Remove labels from issues or pull requests
 
 ### Issues
-- [**create-issue**](./issues.md) - Create new issues
+- [**create-issue**](./issues/) - Create new issues
   - Configuration: `max` (maximum number to create)
-- [**close-issue**](./issues.md) - Close issues
+- [**close-issue**](./issues/) - Close issues
 
 ### Pull Requests
-- [**create-pr**](./pull-requests.md) - Create pull requests
+- [**create-pr**](./pull-requests/) - Create pull requests
   - Configuration: `sign` (sign commits), `max` (maximum to create)
-- [**close-pr**](./pull-requests.md) - Close pull requests
+- [**close-pr**](./pull-requests/) - Close pull requests
 
 ### Files
-- [**update-file**](./files.md) - Modify files in the repository
+- [**update-file**](./files/) - Modify files in the repository
   - Configuration: `sign` (sign commits)
   - Requires: `allowed-paths` allowlist
 
 ### Discussions
-- [**create-discussion**](./discussions.md) - Create discussions
+- [**create-discussion**](./discussions/) - Create discussions
   - Configuration: `max` (maximum number to create)
 
 ## Quick Examples
@@ -193,6 +193,6 @@ When using `allowed-paths` with `update-file` or `create-pr`, use glob patterns:
 ## Next Steps
 
 - Explore specific output types in the sections above
-- Learn about [Permissions](../permissions/)
+- Learn about [Permissions](../../guide/permissions/)
 - Review [Security Considerations](../../reference/security/)
 - See [Examples](../../examples/issue-triage/)

--- a/docs/src/content/docs/outputs/issues.md
+++ b/docs/src/content/docs/outputs/issues.md
@@ -477,9 +477,9 @@ Refine agent logic to:
 
 ## Related Outputs
 
-- [Comments (add-comment)](./comments.md) - Pair with issue management
-- [Labels (add-label, remove-label)](./labels.md) - For issue organization
-- [Pull Requests (create-pr, close-pr)](./pull-requests.md) - For PR management
+- [Comments (add-comment)](./comments/) - Pair with issue management
+- [Labels (add-label, remove-label)](./labels/) - For issue organization
+- [Pull Requests (create-pr, close-pr)](./pull-requests/) - For PR management
 
 ## Next Steps
 

--- a/docs/src/content/docs/outputs/labels.md
+++ b/docs/src/content/docs/outputs/labels.md
@@ -398,12 +398,12 @@ Improve consistency by:
 
 ## Related Outputs
 
-- [Comments (add-comment)](./comments.md) - Pair with labels for issue triage
-- [Issues (create-issue, close-issue)](./issues.md) - For issue management workflows
-- [Pull Requests (create-pr, close-pr)](./pull-requests.md) - For PR workflows
+- [Comments (add-comment)](./comments/) - Pair with labels for issue triage
+- [Issues (create-issue, close-issue)](./issues/) - For issue management workflows
+- [Pull Requests (create-pr, close-pr)](./pull-requests/) - For PR workflows
 
 ## Next Steps
 
 - Learn about [Triggers](../../triggers/) to control when label operations run
-- Explore [Issue Management](./issues.md)
+- Explore [Issue Management](./issues/)
 - Review [Security Best Practices](../../reference/security/)

--- a/docs/src/content/docs/outputs/pull-requests.md
+++ b/docs/src/content/docs/outputs/pull-requests.md
@@ -633,13 +633,13 @@ If PRs modify files outside `allowed-paths`:
 
 ## Related Outputs
 
-- [Comments (add-comment)](./comments.md) - Pair with PRs for feedback
-- [Labels (add-label, remove-label)](./labels.md) - For PR organization
-- [Files (update-file)](./files.md) - For file modifications without PRs
-- [Issues (create-issue, close-issue)](./issues.md) - For issue management
+- [Comments (add-comment)](./comments/) - Pair with PRs for feedback
+- [Labels (add-label, remove-label)](./labels/) - For PR organization
+- [Files (update-file)](./files/) - For file modifications without PRs
+- [Issues (create-issue, close-issue)](./issues/) - For issue management
 
 ## Next Steps
 
-- Learn about [Permissions](../permissions/)
-- Explore [File Modifications](./files.md)
+- Learn about [Permissions](../../guide/permissions/)
+- Explore [File Modifications](./files/)
 - Review [Security Best Practices](../../reference/security/)


### PR DESCRIPTION
## Summary
- Fixed broken permission links in outputs directory (`../permissions/` → `../../guide/permissions/`)
- Standardized link format to directory-style (`./file.md` → `./file/`)
- All outputs pages now use consistent link patterns

This is a focused consistency pass addressing the link format inconsistencies identified in #68. The full consistency pass has many items; this PR addresses the most impactful linking issues.

## Test plan
- [x] Documentation builds successfully (62 pages)
- [x] Links resolve correctly (verified path structure)

Fixes part of #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)