### PR TITLE
fix: allow GitHub App bot to trigger Issue Triage agent

### DIFF
--- a/.github/claude-agents/issue-triage.md
+++ b/.github/claude-agents/issue-triage.md
@@ -9,6 +9,8 @@ permissions:
 outputs:
   add-comment: { max: 1 }
   add-label: true
+allowed-actors:
+  - claude-of-luca[bot]
 trigger_labels: []
 rate_limit_minutes: 1
 ---

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -164,7 +164,7 @@ jobs:
           fi
 
           # Allowed if: admin, write access, org member, or in explicit allow list
-          ALLOWED_USERS=""
+          ALLOWED_USERS="claude-of-luca[bot]"
           IS_ALLOWED="false"
 
           if [ "${USER_ASSOCIATION}" = "admin" ] || [ "${USER_ASSOCIATION}" = "write" ]; then
@@ -715,7 +715,7 @@ jobs:
           echo "git-user=$APP_SLUG[bot]" >> $GITHUB_OUTPUT
           echo "git-email=$APP_ID_NUM+$APP_SLUG[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
       - name: Download outputs artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: agent-outputs
           path: /tmp/outputs
@@ -917,7 +917,7 @@ jobs:
     if: always()
     steps:
       - name: Download all validation results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           pattern: validation-results-*
           path: /tmp/all-validation-errors
@@ -1059,19 +1059,19 @@ jobs:
     if: always()
     steps:
       - name: Download validation audit
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: validation-audit
           path: /tmp/audit-data/validation
         continue-on-error: true
       - name: Download execution metrics
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: audit-metrics
           path: /tmp/audit-data/metrics
         continue-on-error: true
       - name: Download output validation results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           pattern: validation-results-*
           path: /tmp/audit-data/outputs


### PR DESCRIPTION
## Summary
- Add `claude-of-luca[bot]` to `allowed-actors` in the Issue Triage agent
- This allows the Issue Triage workflow to run when issues are created by the GitHub App bot (e.g., from the Failure & Issue Alerts agent)

## Root Cause
The Issue Triage agent was failing because `claude-of-luca[bot]` was not authorized to trigger it. When the Failure Alerts agent creates an alert issue, the actor is the GitHub App bot, which was being rejected by the authorization check.

## Test plan
- [x] All tests pass (`bun test`)
- [x] Agent validates successfully (`gh claude validate`)
- [x] Workflow compiles without errors
- [ ] Verify Issue Triage runs on next bot-created issue

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)