### PR TITLE
fix(runtime): use OR logic for trigger_labels

### DIFF
--- a/packages/runtime/src/stages/unified/route.ts
+++ b/packages/runtime/src/stages/unified/route.ts
@@ -319,11 +319,14 @@ async function handleClosedIssueRetries(
           continue;
         }
 
-        // Check if this issue has the required trigger labels for this agent
-        const requiredLabels = agent.config.trigger_labels || [];
-        const hasAllLabels = requiredLabels.every((required) => labels.includes(required));
+        // Check if this issue has any of the trigger labels for this agent (OR logic)
+        const triggerLabels = agent.config.trigger_labels || [];
+        // If no trigger labels configured, agent matches all issues
+        // Otherwise, check if ANY trigger label is present
+        const hasAnyTriggerLabel =
+          triggerLabels.length === 0 || triggerLabels.some((label) => labels.includes(label));
 
-        if (hasAllLabels && !matchingAgents.some((a) => a.name === agent.name)) {
+        if (hasAnyTriggerLabel && !matchingAgents.some((a) => a.name === agent.name)) {
           console.log(`    -> Matching agent: ${agent.name}`);
           matchingAgents.push(agent);
         }


### PR DESCRIPTION
## Summary

- Fixes the bug where `trigger_labels` required ALL labels to be present (AND logic) instead of ANY label (OR logic)
- Updates `handleClosedIssueRetries` in route.ts to use `some()` instead of `every()` for label matching
- Adds comprehensive tests for `checkTriggerLabels` to verify OR logic behavior

## Root Cause

In `route.ts:324`, the code was using:
```typescript
const hasAllLabels = requiredLabels.every((required) => labels.includes(required));
```

This required ALL trigger labels to be present, but the expected behavior is that ANY trigger label should match.

## Fix

Changed to OR logic:
```typescript
const hasAnyTriggerLabel = triggerLabels.length === 0 || triggerLabels.some((label) => labels.includes(label));
```

## Test plan

- [x] Added tests verifying OR logic for trigger_labels
- [x] Tests verify first label matches, second label matches, both labels match, and no labels fail
- [x] Tests verify non-issue events (pull_request, schedule, workflow_dispatch) bypass label check
- [x] All existing tests pass

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)