### PR TITLE
feat(timeout): add configurable execution timeouts

### DIFF
--- a/packages/generator/src/__snapshots__/unified.test.ts.snap
+++ b/packages/generator/src/__snapshots__/unified.test.ts.snap
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: dispatcher
     if: needs.dispatcher.outputs.agent-test-agent-should-run == 'true'
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -65,6 +66,7 @@ jobs:
           git config --global user.email "\${{ steps.app-token.outputs.app-slug || 'github-actions[bot]' }}@users.noreply.github.com"
       - name: Run Test Agent
         run: bun run repo-agent run agent --agent "Test Agent"
+        timeout-minutes: 30
         env:
           GH_TOKEN: \${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}

--- a/packages/parser/src/index.test.ts
+++ b/packages/parser/src/index.test.ts
@@ -318,6 +318,47 @@ Rate limit test`;
         expect(result.agent?.rate_limit_minutes).toBe(15);
       });
 
+      it("should parse agent with simple timeout (number)", () => {
+        const content = `---
+name: Timeout Agent
+on:
+  issues:
+    types: [opened]
+timeout: 20
+---
+
+Timeout test`;
+
+        const result = parser.parseContent(content);
+
+        expect(result.agent).toBeDefined();
+        expect(result.agent?.timeout).toBe(20);
+      });
+
+      it("should parse agent with detailed timeout config", () => {
+        const content = `---
+name: Detailed Timeout Agent
+on:
+  issues:
+    types: [opened]
+timeout:
+  execution: 15
+  total: 25
+  context_collection: 3
+---
+
+Timeout test`;
+
+        const result = parser.parseContent(content);
+
+        expect(result.agent).toBeDefined();
+        expect(result.agent?.timeout).toEqual({
+          execution: 15,
+          total: 25,
+          context_collection: 3,
+        });
+      });
+
       it("should parse agent with context configuration", () => {
         const content = `---
 name: Context Agent

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -96,8 +96,13 @@ export class AgentParser {
       trigger_labels: frontmatter.trigger_labels,
       max_open_prs: frontmatter.max_open_prs,
       rate_limit_minutes: frontmatter.rate_limit_minutes,
+      pre_flight: frontmatter.pre_flight,
       context: frontmatter.context,
       audit: frontmatter.audit,
+      progress_comment: frontmatter.progress_comment,
+      allow_bot_triggers: frontmatter.allow_bot_triggers,
+      concurrency: frontmatter.concurrency,
+      timeout: frontmatter.timeout,
       markdown: parsed.content.trim(),
     };
 

--- a/packages/parser/src/schemas.ts
+++ b/packages/parser/src/schemas.ts
@@ -337,6 +337,25 @@ const concurrencyConfigSchema = z
   ])
   .optional();
 
+const timeoutConfigSchema = z
+  .union([
+    // Simple number: execution timeout in minutes
+    z
+      .number()
+      .min(1)
+      .max(360),
+    // Detailed config object
+    z.object({
+      // Agent execution timeout in minutes (default: 30)
+      execution: z.number().min(1).max(360).optional(),
+      // Total job timeout in minutes (default: 45)
+      total: z.number().min(1).max(360).optional(),
+      // Context collection timeout in minutes (default: 5)
+      context_collection: z.number().min(1).max(60).optional(),
+    }),
+  ])
+  .optional();
+
 export const agentFrontmatterSchema = z.strictObject({
   name: z.string().min(1, { message: "Agent name is required" }),
   on: triggerConfigSchema,
@@ -357,6 +376,7 @@ export const agentFrontmatterSchema = z.strictObject({
   progress_comment: z.boolean().optional(), // Show progress comment on issue/PR (default: true for issue/PR triggers)
   allow_bot_triggers: z.boolean().optional(), // Allow bot/app actors to trigger this agent (default: false, prevents recursive loops)
   concurrency: concurrencyConfigSchema, // Concurrency settings for debouncing (default: auto-generated based on trigger)
+  timeout: timeoutConfigSchema, // Execution timeout in minutes or detailed config
 }); // Reject unknown properties
 
 export type AgentFrontmatter = z.infer<typeof agentFrontmatterSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,6 +25,7 @@ export interface AgentDefinition {
   progress_comment?: boolean; // Show progress comment on issue/PR (default: true for issue/PR triggers)
   allow_bot_triggers?: boolean; // Allow bot/app actors to trigger this agent (default: false, prevents recursive loops)
   concurrency?: ConcurrencyConfig | false; // Concurrency settings for debouncing (default: auto-generated based on trigger)
+  timeout?: number | TimeoutConfig; // Execution timeout in minutes (number) or detailed config
   markdown: string;
 }
 
@@ -37,6 +38,12 @@ export interface AuditConfig {
 export interface ConcurrencyConfig {
   group?: string; // Custom concurrency group (supports GitHub expressions)
   cancel_in_progress?: boolean; // Whether to cancel in-progress runs (default: true)
+}
+
+export interface TimeoutConfig {
+  execution?: number; // Agent execution timeout in minutes (default: 30)
+  total?: number; // Total job timeout in minutes (default: 45)
+  context_collection?: number; // Context collection timeout in minutes (default: 5)
 }
 
 export interface TriggerConfig {
@@ -156,6 +163,7 @@ export interface WorkflowStep {
   env?: Record<string, string>;
   if?: string;
   "continue-on-error"?: boolean;
+  "timeout-minutes"?: number;
 }
 
 // Context Configuration Types


### PR DESCRIPTION
## Summary

- Adds support for configurable timeout settings for agent execution
- Prevents runaway agents and helps manage GitHub Actions minutes
- Supports both simple number form and detailed config object

## Configuration Examples

**Simple number (execution timeout):**
```yaml
timeout: 20  # 20 minute execution, 35 min total (derived)
```

**Detailed config:**
```yaml
timeout:
  execution: 15      # Agent execution timeout
  total: 25          # Total job timeout  
  context_collection: 3  # Context collection timeout
```

## Default Timeouts

| Setting | Default |
|---------|---------|
| Execution | 30 min |
| Total | 45 min |
| Context Collection | 5 min |

## Test plan

- [x] Parser tests for simple number timeout
- [x] Parser tests for detailed timeout config
- [x] Generator tests for default timeout application
- [x] Generator tests for custom timeout values
- [x] Generator tests for context collection timeout
- [x] Snapshot updated with new timeout fields

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)