### PR TITLE
feat(deduplication): add smart deduplication to prevent redundant agent actions

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -105,6 +105,7 @@ export class AgentParser {
       concurrency: frontmatter.concurrency,
       timeout: frontmatter.timeout,
       tracing: frontmatter.tracing,
+      deduplication: frontmatter.deduplication,
       markdown: parsed.content.trim(),
     };
 


### PR DESCRIPTION
## Summary
- Adds intelligent deduplication to prevent agents from performing redundant actions
- Event deduplication prevents processing the same event twice within a configurable time window
- Action deduplication prevents repeating the same action (exact or similar match modes)

## Configuration
```yaml
deduplication:
  events:
    enabled: true
    window: 1h
    key: [event_type, issue_number, action]
  actions:
    enabled: true
    window: 24h
    match: exact  # or "similar"
```

## Test plan
- [x] Added unit tests for deduplication utilities
- [x] Added tests for event deduplication
- [x] Added tests for action deduplication
- [x] TypeScript compiles without errors
- [x] All existing tests pass

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)