### PR TITLE
feat(tracing): add execution tracing for detailed agent action logs

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -94,6 +94,7 @@ export class AgentParser {
       allowed_teams: frontmatter["allowed-teams"],
       allowed_paths: frontmatter["allowed-paths"],
       trigger_labels: frontmatter.trigger_labels,
+      skip_labels: frontmatter.skip_labels,
       max_open_prs: frontmatter.max_open_prs,
       rate_limit_minutes: frontmatter.rate_limit_minutes,
       pre_flight: frontmatter.pre_flight,
@@ -103,6 +104,7 @@ export class AgentParser {
       allow_bot_triggers: frontmatter.allow_bot_triggers,
       concurrency: frontmatter.concurrency,
       timeout: frontmatter.timeout,
+      tracing: frontmatter.tracing,
       markdown: parsed.content.trim(),
     };
 

--- a/packages/runtime/src/utils/tracing.test.ts
+++ b/packages/runtime/src/utils/tracing.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentDefinition } from "@repo-agents/types";
+import {
+  createTracer,
+  ExecutionTracer,
+  formatTraceTimeline,
+  getTraceLevel,
+  isTracingEnabled,
+} from "./tracing";
+
+describe("ExecutionTracer", () => {
+  describe("constructor", () => {
+    it("should create a trace with default config", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123");
+      const trace = tracer.getTrace();
+
+      expect(trace.agent_name).toBe("test-agent");
+      expect(trace.workflow_run_id).toBe("run-123");
+      expect(trace.level).toBe("summary");
+      expect(trace.status).toBe("running");
+      expect(trace.schema_version).toBe("1.0.0");
+      expect(trace.trace_id).toBeDefined();
+    });
+
+    it("should create a trace with custom config", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+        retention: "30d",
+      });
+      const trace = tracer.getTrace();
+
+      expect(trace.level).toBe("detailed");
+      expect(trace.steps).toBeDefined();
+      expect(trace.decisions).toBeDefined();
+    });
+
+    it("should initialize tool_calls array for debug level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "debug",
+      });
+      const trace = tracer.getTrace();
+
+      expect(trace.level).toBe("debug");
+      expect(trace.tool_calls).toBeDefined();
+    });
+  });
+
+  describe("recordStep", () => {
+    it("should update action counts for summary level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "summary",
+      });
+
+      tracer.recordStep("read", "src/file.ts", "success", 10);
+      tracer.recordStep("read", "src/other.ts", "success", 15);
+      tracer.recordStep("analyze", undefined, "success", 100);
+
+      const trace = tracer.getTrace();
+      expect(trace.summary.actions).toContain("read 2 times");
+      expect(trace.summary.actions).toContain("analyze 1 time");
+    });
+
+    it("should record detailed steps for detailed level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordStep("read", "src/file.ts", "success", 10, { lines: 100 });
+
+      const trace = tracer.getTrace();
+      expect(trace.steps).toHaveLength(1);
+      expect(trace.steps?.[0].action).toBe("read");
+      expect(trace.steps?.[0].target).toBe("src/file.ts");
+      expect(trace.steps?.[0].result).toBe("success");
+      expect(trace.steps?.[0].duration_ms).toBe(10);
+      expect(trace.steps?.[0].details).toEqual({ lines: 100 });
+    });
+
+    it("should not record detailed steps for summary level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "summary",
+      });
+
+      tracer.recordStep("read", "src/file.ts", "success", 10);
+
+      const trace = tracer.getTrace();
+      expect(trace.steps).toBeUndefined();
+    });
+  });
+
+  describe("recordDecision", () => {
+    it("should record decisions for detailed level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordDecision(
+        "Should comment on line 45?",
+        "Potential null pointer",
+        "Yes, add suggestion",
+        "No existing comment on this line",
+      );
+
+      const trace = tracer.getTrace();
+      expect(trace.decisions).toHaveLength(1);
+      expect(trace.decisions?.[0].question).toBe("Should comment on line 45?");
+      expect(trace.decisions?.[0].output).toBe("Yes, add suggestion");
+    });
+
+    it("should not record decisions for summary level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "summary",
+      });
+
+      tracer.recordDecision("Question?", "Input", "Output");
+
+      const trace = tracer.getTrace();
+      expect(trace.decisions).toBeUndefined();
+    });
+  });
+
+  describe("recordToolCall", () => {
+    it("should update tool call counts", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "summary",
+      });
+
+      tracer.recordToolCall("Read", { path: "/file.ts" }, "success", 50);
+      tracer.recordToolCall("Write", { path: "/file.ts" }, "failure", 100, "Permission denied");
+      tracer.recordToolCall("Bash", { command: "ls" }, "success", 20);
+
+      const trace = tracer.getTrace();
+      expect(trace.summary.total_tool_calls).toBe(3);
+      expect(trace.summary.successful_tool_calls).toBe(2);
+      expect(trace.summary.failed_tool_calls).toBe(1);
+    });
+
+    it("should record detailed tool calls for debug level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "debug",
+      });
+
+      tracer.recordToolCall("Read", { path: "/file.ts" }, "success", 50);
+
+      const trace = tracer.getTrace();
+      expect(trace.tool_calls).toHaveLength(1);
+      expect(trace.tool_calls?.[0].tool).toBe("Read");
+      expect(trace.tool_calls?.[0].parameters).toEqual({ path: "/file.ts" });
+    });
+
+    it("should not record detailed tool calls for detailed level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordToolCall("Read", { path: "/file.ts" }, "success", 50);
+
+      const trace = tracer.getTrace();
+      expect(trace.tool_calls).toBeUndefined();
+    });
+  });
+
+  describe("complete", () => {
+    it("should finalize the trace", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123");
+
+      tracer.recordStep("read", "file.ts", "success");
+      const trace = tracer.complete("success");
+
+      expect(trace.status).toBe("success");
+      expect(trace.completed_at).toBeDefined();
+      expect(trace.summary.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should include raw output for debug level", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "debug",
+      });
+
+      const trace = tracer.complete("success", "Raw output here");
+
+      expect(trace.raw_output).toBe("Raw output here");
+    });
+  });
+
+  describe("redaction", () => {
+    it("should redact secrets by default", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordStep("read", "config with password=secret123", "success");
+
+      const trace = tracer.getTrace();
+      expect(trace.steps?.[0].target).not.toContain("secret123");
+      expect(trace.steps?.[0].target).toContain("[REDACTED]");
+    });
+
+    it("should redact GitHub tokens", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordStep("api", "Token: ghp_1234567890abcdef", "success");
+
+      const trace = tracer.getTrace();
+      expect(trace.steps?.[0].target).not.toContain("ghp_1234567890abcdef");
+      expect(trace.steps?.[0].target).toContain("[REDACTED]");
+    });
+
+    it("should redact API keys", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+      });
+
+      tracer.recordStep("api", "Key: sk-1234567890abcdef", "success");
+
+      const trace = tracer.getTrace();
+      expect(trace.steps?.[0].target).not.toContain("sk-1234567890abcdef");
+      expect(trace.steps?.[0].target).toContain("[REDACTED]");
+    });
+
+    it("should apply custom redaction patterns", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+        redact: {
+          patterns: ["customsecret\\d+"],
+        },
+      });
+
+      tracer.recordStep("read", "Found customsecret12345 in file", "success");
+
+      const trace = tracer.getTrace();
+      expect(trace.steps?.[0].target).not.toContain("customsecret12345");
+      expect(trace.steps?.[0].target).toContain("[REDACTED]");
+    });
+
+    it("should truncate long file contents", () => {
+      const tracer = new ExecutionTracer("test-agent", "run-123", {
+        level: "detailed",
+        redact: {
+          file_contents_over: 5,
+        },
+      });
+
+      const longContent = "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8";
+      tracer.recordStep("read", longContent, "success");
+
+      const trace = tracer.getTrace();
+      expect(trace.steps?.[0].target).toContain("[truncated");
+      expect(trace.steps?.[0].target?.split("\n").length).toBeLessThanOrEqual(6);
+    });
+  });
+});
+
+describe("formatTraceTimeline", () => {
+  it("should format a summary trace", () => {
+    const tracer = new ExecutionTracer("test-agent", "run-123", {
+      level: "summary",
+    });
+
+    tracer.recordStep("read", "file.ts", "success");
+    tracer.recordStep("read", "other.ts", "success");
+    tracer.recordToolCall("Read", {}, "success", 10);
+
+    const trace = tracer.complete("success");
+    const timeline = formatTraceTimeline(trace);
+
+    expect(timeline).toContain("test-agent execution timeline");
+    expect(timeline).toContain("summary");
+    expect(timeline).toContain("read 2 times");
+  });
+
+  it("should format a detailed trace", () => {
+    const tracer = new ExecutionTracer("test-agent", "run-123", {
+      level: "detailed",
+    });
+
+    tracer.recordStep("read", "file.ts", "success", 10);
+    tracer.recordStep("analyze", undefined, "success", 50);
+    tracer.recordToolCall("Read", {}, "success", 10);
+    tracer.recordToolCall("Bash", {}, "failure", 5);
+
+    const trace = tracer.complete("success");
+    const timeline = formatTraceTimeline(trace);
+
+    expect(timeline).toContain("test-agent execution timeline");
+    expect(timeline).toContain("read");
+    expect(timeline).toContain("analyze");
+    expect(timeline).toContain("1/2 successful");
+  });
+});
+
+describe("createTracer", () => {
+  it("should create a tracer with agent config", () => {
+    const agent: AgentDefinition = {
+      name: "test-agent",
+      on: { issues: { types: ["opened"] } },
+      tracing: { level: "detailed" },
+      markdown: "",
+    };
+
+    const tracer = createTracer(agent, "run-123");
+    const trace = tracer.getTrace();
+
+    expect(trace.agent_name).toBe("test-agent");
+    expect(trace.level).toBe("detailed");
+  });
+
+  it("should create a tracer with default config if no tracing specified", () => {
+    const agent: AgentDefinition = {
+      name: "test-agent",
+      on: { issues: { types: ["opened"] } },
+      markdown: "",
+    };
+
+    const tracer = createTracer(agent, "run-123");
+    const trace = tracer.getTrace();
+
+    expect(trace.level).toBe("summary");
+  });
+});
+
+describe("isTracingEnabled", () => {
+  it("should return true if tracing is configured", () => {
+    const agent: AgentDefinition = {
+      name: "test",
+      on: {},
+      tracing: { level: "detailed" },
+      markdown: "",
+    };
+
+    expect(isTracingEnabled(agent)).toBe(true);
+  });
+
+  it("should return false if tracing is not configured", () => {
+    const agent: AgentDefinition = {
+      name: "test",
+      on: {},
+      markdown: "",
+    };
+
+    expect(isTracingEnabled(agent)).toBe(false);
+  });
+});
+
+describe("getTraceLevel", () => {
+  it("should return configured level", () => {
+    const agent: AgentDefinition = {
+      name: "test",
+      on: {},
+      tracing: { level: "debug" },
+      markdown: "",
+    };
+
+    expect(getTraceLevel(agent)).toBe("debug");
+  });
+
+  it("should return summary as default", () => {
+    const agent: AgentDefinition = {
+      name: "test",
+      on: {},
+      markdown: "",
+    };
+
+    expect(getTraceLevel(agent)).toBe("summary");
+  });
+});

--- a/packages/runtime/src/utils/tracing.ts
+++ b/packages/runtime/src/utils/tracing.ts
@@ -1,0 +1,336 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AgentDefinition,
+  ExecutionTrace,
+  ToolCall,
+  TraceDecision,
+  TraceEntry,
+  TraceLevel,
+  TracingConfig,
+} from "@repo-agents/types";
+
+/**
+ * Default tracing configuration
+ */
+const DEFAULT_TRACING_CONFIG: TracingConfig = {
+  level: "summary",
+  retention: "7d",
+  include: ["tool-calls", "timing"],
+  exclude: ["secrets"],
+  redact: {
+    secrets: true,
+    file_contents_over: 100,
+  },
+};
+
+/**
+ * Patterns to redact from traces
+ */
+const SECRET_PATTERNS = [
+  /password["\s:=]+["']?[^"'\s]+["']?/gi,
+  /api[_-]?key["\s:=]+["']?[^"'\s]+["']?/gi,
+  /token["\s:=]+["']?[^"'\s]+["']?/gi,
+  /secret["\s:=]+["']?[^"'\s]+["']?/gi,
+  /bearer\s+[a-zA-Z0-9\-_]+/gi,
+  /ghp_[a-zA-Z0-9]+/g, // GitHub Personal Access Token
+  /gho_[a-zA-Z0-9]+/g, // GitHub OAuth Token
+  /ghs_[a-zA-Z0-9]+/g, // GitHub App Token
+  /sk-[a-zA-Z0-9]+/g, // OpenAI/Anthropic API Key
+];
+
+/**
+ * Execution tracer for tracking agent actions.
+ */
+export class ExecutionTracer {
+  private trace: ExecutionTrace;
+  private config: TracingConfig;
+  private startTime: number;
+  private actionCounts: Map<string, number> = new Map();
+
+  constructor(agentName: string, workflowRunId: string, config?: TracingConfig) {
+    this.config = { ...DEFAULT_TRACING_CONFIG, ...config };
+    this.startTime = Date.now();
+
+    this.trace = {
+      schema_version: "1.0.0",
+      trace_id: randomUUID(),
+      agent_name: agentName,
+      workflow_run_id: workflowRunId,
+      level: this.config.level ?? "summary",
+      started_at: new Date().toISOString(),
+      status: "running",
+      summary: {
+        duration_ms: 0,
+        actions: [],
+        total_tool_calls: 0,
+        successful_tool_calls: 0,
+        failed_tool_calls: 0,
+      },
+    };
+
+    // Initialize arrays for detailed/debug levels
+    if (this.config.level === "detailed" || this.config.level === "debug") {
+      this.trace.steps = [];
+      this.trace.decisions = [];
+    }
+
+    if (this.config.level === "debug") {
+      this.trace.tool_calls = [];
+    }
+  }
+
+  /**
+   * Record a step in the execution.
+   */
+  recordStep(
+    action: string,
+    target: string | undefined,
+    result: "success" | "failure" | "skipped",
+    durationMs?: number,
+    details?: Record<string, unknown>,
+  ): void {
+    // Update action counts for summary
+    const currentCount = this.actionCounts.get(action) ?? 0;
+    this.actionCounts.set(action, currentCount + 1);
+
+    // Only record detailed steps if level is detailed or debug
+    if (this.config.level === "detailed" || this.config.level === "debug") {
+      const entry: TraceEntry = {
+        timestamp: new Date().toISOString(),
+        elapsed_ms: Date.now() - this.startTime,
+        action,
+        target: this.redactSensitive(target),
+        result,
+        duration_ms: durationMs,
+        details: details ? this.redactObject(details) : undefined,
+      };
+
+      this.trace.steps?.push(entry);
+    }
+  }
+
+  /**
+   * Record a decision made during execution.
+   */
+  recordDecision(question: string, input: string, output: string, reasoning?: string): void {
+    if (this.config.level === "detailed" || this.config.level === "debug") {
+      const decision: TraceDecision = {
+        timestamp: new Date().toISOString(),
+        question,
+        input: this.redactSensitive(input) ?? "",
+        output: this.redactSensitive(output) ?? "",
+        reasoning: reasoning ? this.redactSensitive(reasoning) : undefined,
+      };
+
+      this.trace.decisions?.push(decision);
+    }
+  }
+
+  /**
+   * Record a tool call.
+   */
+  recordToolCall(
+    tool: string,
+    parameters: Record<string, unknown>,
+    result: "success" | "failure",
+    durationMs: number,
+    error?: string,
+  ): void {
+    this.trace.summary.total_tool_calls++;
+    if (result === "success") {
+      this.trace.summary.successful_tool_calls++;
+    } else {
+      this.trace.summary.failed_tool_calls++;
+    }
+
+    // Only record detailed tool calls if level is debug
+    if (this.config.level === "debug") {
+      const toolCall: ToolCall = {
+        timestamp: new Date().toISOString(),
+        tool,
+        parameters: this.redactObject(parameters),
+        result,
+        duration_ms: durationMs,
+        error: error ? this.redactSensitive(error) : undefined,
+      };
+
+      this.trace.tool_calls?.push(toolCall);
+    }
+  }
+
+  /**
+   * Complete the trace with final status.
+   */
+  complete(status: "success" | "failure" | "cancelled", rawOutput?: string): ExecutionTrace {
+    this.trace.status = status;
+    this.trace.completed_at = new Date().toISOString();
+    this.trace.summary.duration_ms = Date.now() - this.startTime;
+
+    // Generate action summary
+    this.trace.summary.actions = Array.from(this.actionCounts.entries()).map(
+      ([action, count]) => `${action} ${count} ${count === 1 ? "time" : "times"}`,
+    );
+
+    // Add raw output if debug level
+    if (this.config.level === "debug" && rawOutput) {
+      this.trace.raw_output = this.redactSensitive(rawOutput);
+    }
+
+    return this.trace;
+  }
+
+  /**
+   * Get the current trace state.
+   */
+  getTrace(): ExecutionTrace {
+    return {
+      ...this.trace,
+      summary: {
+        ...this.trace.summary,
+        duration_ms: Date.now() - this.startTime,
+        actions: Array.from(this.actionCounts.entries()).map(
+          ([action, count]) => `${action} ${count} ${count === 1 ? "time" : "times"}`,
+        ),
+      },
+    };
+  }
+
+  /**
+   * Get the trace ID.
+   */
+  getTraceId(): string {
+    return this.trace.trace_id;
+  }
+
+  /**
+   * Redact sensitive information from a string.
+   */
+  private redactSensitive(value: string | undefined): string | undefined {
+    if (!value) return value;
+
+    let redacted = value;
+
+    // Apply built-in secret patterns if secrets redaction is enabled
+    if (this.config.redact?.secrets !== false) {
+      for (const pattern of SECRET_PATTERNS) {
+        redacted = redacted.replace(pattern, "[REDACTED]");
+      }
+    }
+
+    // Apply custom patterns
+    if (this.config.redact?.patterns) {
+      for (const pattern of this.config.redact.patterns) {
+        try {
+          const regex = new RegExp(pattern, "gi");
+          redacted = redacted.replace(regex, "[REDACTED]");
+        } catch {
+          // Invalid regex, skip
+        }
+      }
+    }
+
+    // Truncate file contents if configured
+    if (this.config.redact?.file_contents_over) {
+      const lines = redacted.split("\n");
+      if (lines.length > this.config.redact.file_contents_over) {
+        redacted =
+          lines.slice(0, this.config.redact.file_contents_over).join("\n") +
+          `\n... [truncated ${lines.length - this.config.redact.file_contents_over} lines]`;
+      }
+    }
+
+    return redacted;
+  }
+
+  /**
+   * Redact sensitive information from an object.
+   */
+  private redactObject(obj: Record<string, unknown>): Record<string, unknown> {
+    const redacted: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === "string") {
+        redacted[key] = this.redactSensitive(value);
+      } else if (typeof value === "object" && value !== null) {
+        redacted[key] = this.redactObject(value as Record<string, unknown>);
+      } else {
+        redacted[key] = value;
+      }
+    }
+
+    return redacted;
+  }
+}
+
+/**
+ * Format a trace as a timeline string for display.
+ */
+export function formatTraceTimeline(trace: ExecutionTrace): string {
+  const lines: string[] = [];
+
+  lines.push(`${trace.agent_name} execution timeline:`);
+  lines.push("");
+
+  if (!trace.steps || trace.steps.length === 0) {
+    lines.push("No detailed steps recorded (trace level: summary)");
+    lines.push("");
+    lines.push("Summary:");
+    for (const action of trace.summary.actions) {
+      lines.push(`  - ${action}`);
+    }
+    return lines.join("\n");
+  }
+
+  // Format each step as a timeline entry
+  for (const step of trace.steps) {
+    const elapsed = formatElapsed(step.elapsed_ms);
+    const status = step.result === "success" ? "✓" : step.result === "failure" ? "✗" : "○";
+    const duration = step.duration_ms ? ` (${step.duration_ms}ms)` : "";
+    const target = step.target ? ` ${step.target}` : "";
+
+    lines.push(`${elapsed} ─── ${status} ${step.action}${target}${duration}`);
+  }
+
+  lines.push("");
+  lines.push(`Total duration: ${formatElapsed(trace.summary.duration_ms)}`);
+  lines.push(
+    `Tool calls: ${trace.summary.successful_tool_calls}/${trace.summary.total_tool_calls} successful`,
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Format milliseconds as a human-readable time string.
+ */
+function formatElapsed(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+  }
+  return `0:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Create a tracer for an agent based on its configuration.
+ */
+export function createTracer(agent: AgentDefinition, workflowRunId: string): ExecutionTracer {
+  return new ExecutionTracer(agent.name, workflowRunId, agent.tracing);
+}
+
+/**
+ * Check if tracing is enabled for the agent.
+ */
+export function isTracingEnabled(agent: AgentDefinition): boolean {
+  return agent.tracing !== undefined;
+}
+
+/**
+ * Get the trace level for an agent.
+ */
+export function getTraceLevel(agent: AgentDefinition): TraceLevel {
+  return agent.tracing?.level ?? "summary";
+}


### PR DESCRIPTION
## Summary
- Adds detailed execution tracing to provide visibility into agent actions
- Three trace levels: summary (default), detailed, and debug
- Step recording, decision tracking, and tool call monitoring
- Privacy controls with secret redaction and file truncation

## Configuration
```yaml
tracing:
  level: detailed
  retention: 7d
  include: [tool-calls, decisions, timing]
  exclude: [secrets]
  redact:
    secrets: true
    patterns: ["customsecret\\d+"]
    file_contents_over: 100
```

## Test plan
- [x] Added unit tests for ExecutionTracer class
- [x] Added tests for redaction functionality
- [x] Added tests for timeline formatting
- [x] TypeScript compiles without errors
- [x] All existing tests pass

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)