### PR TITLE
feat(blueprints): add agent blueprint system for reusable templates

### DIFF
--- a/packages/parser/src/blueprint.test.ts
+++ b/packages/parser/src/blueprint.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from "bun:test";
+import type { BlueprintMetadata } from "@repo-agents/types";
+import {
+  applyTemplate,
+  applyTemplateToObject,
+  extendsBlueprint,
+  isBlueprint,
+  mergeWithDefaults,
+  parseBlueprintContent,
+  parseBlueprintInstance,
+  resolveBlueprintSource,
+  validateParameters,
+} from "./blueprint";
+
+describe("parseBlueprintContent", () => {
+  test("should parse valid blueprint content", () => {
+    const content = `---
+blueprint:
+  name: triage-blueprint
+  version: "1.0.0"
+  description: A blueprint for triage agents
+  parameters:
+    - name: priority_labels
+      type: array
+      default: ["high", "medium", "low"]
+    - name: response_time
+      type: number
+      default: 24
+name: triage-agent
+on:
+  issues:
+    types: [opened]
+---
+
+You are a triage agent. Use these priority labels: {{ parameters.priority_labels }}
+Respond within {{ parameters.response_time }} hours.
+`;
+
+    const result = parseBlueprintContent(content);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.blueprint).toBeDefined();
+    expect(result.blueprint!.blueprint.name).toBe("triage-blueprint");
+    expect(result.blueprint!.blueprint.version).toBe("1.0.0");
+    expect(result.blueprint!.blueprint.parameters).toHaveLength(2);
+    expect(result.blueprint!.frontmatter.name).toBe("triage-agent");
+    expect(result.blueprint!.markdown).toContain("{{ parameters.priority_labels }}");
+  });
+
+  test("should return error for missing blueprint metadata", () => {
+    const content = `---
+name: triage-agent
+on:
+  issues:
+    types: [opened]
+---
+
+Some content
+`;
+
+    const result = parseBlueprintContent(content);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("blueprint");
+    expect(result.errors[0].message).toContain("required");
+  });
+
+  test("should return error for invalid version format", () => {
+    const content = `---
+blueprint:
+  name: test
+  version: "v1"
+---
+
+Content
+`;
+
+    const result = parseBlueprintContent(content);
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].message).toContain("semver");
+  });
+
+  test("should handle blueprint with enum parameter", () => {
+    const content = `---
+blueprint:
+  name: enum-blueprint
+  version: "1.0.0"
+  parameters:
+    - name: severity
+      type: enum
+      values: ["low", "medium", "high", "critical"]
+      default: medium
+---
+
+Content
+`;
+
+    const result = parseBlueprintContent(content);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.blueprint!.blueprint.parameters[0].values).toEqual([
+      "low",
+      "medium",
+      "high",
+      "critical",
+    ]);
+  });
+});
+
+describe("parseBlueprintInstance", () => {
+  test("should parse valid instance", () => {
+    const frontmatter = {
+      extends: "./blueprints/triage.md",
+      parameters: {
+        priority_labels: ["urgent", "normal"],
+        response_time: 12,
+      },
+    };
+
+    const result = parseBlueprintInstance(frontmatter);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.instance).toBeDefined();
+    expect(result.instance!.extends).toBe("./blueprints/triage.md");
+    expect(result.instance!.parameters).toEqual({
+      priority_labels: ["urgent", "normal"],
+      response_time: 12,
+    });
+  });
+
+  test("should return error for missing extends", () => {
+    const frontmatter = {
+      parameters: { foo: "bar" },
+    };
+
+    const result = parseBlueprintInstance(frontmatter);
+
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("applyTemplate", () => {
+  test("should replace parameter placeholders", () => {
+    const template = "Use these labels: {{ parameters.labels }}";
+    const params = { labels: "bug,feature" };
+
+    const result = applyTemplate(template, params);
+
+    expect(result).toBe("Use these labels: bug,feature");
+  });
+
+  test("should handle array parameters", () => {
+    const template = "Labels: {{ parameters.labels }}";
+    const params = { labels: ["bug", "feature", "enhancement"] };
+
+    const result = applyTemplate(template, params);
+
+    expect(result).toBe('Labels: ["bug","feature","enhancement"]');
+  });
+
+  test("should preserve unresolved placeholders", () => {
+    const template = "{{ parameters.defined }} and {{ parameters.undefined }}";
+    const params = { defined: "value" };
+
+    const result = applyTemplate(template, params);
+
+    expect(result).toBe("value and {{ parameters.undefined }}");
+  });
+
+  test("should handle multiple occurrences", () => {
+    const template = "{{ parameters.name }} is {{ parameters.name }}";
+    const params = { name: "Claude" };
+
+    const result = applyTemplate(template, params);
+
+    expect(result).toBe("Claude is Claude");
+  });
+
+  test("should handle whitespace variations", () => {
+    const template = "{{parameters.a}} {{ parameters.b }} {{  parameters.c  }}";
+    const params = { a: "1", b: "2", c: "3" };
+
+    const result = applyTemplate(template, params);
+
+    expect(result).toBe("1 2 3");
+  });
+});
+
+describe("applyTemplateToObject", () => {
+  test("should recursively apply templates to object", () => {
+    const obj = {
+      name: "{{ parameters.name }}",
+      config: {
+        timeout: "{{ parameters.timeout }}",
+        labels: ["{{ parameters.label1 }}", "{{ parameters.label2 }}"],
+      },
+    };
+    const params = { name: "agent", timeout: "30", label1: "bug", label2: "feature" };
+
+    const result = applyTemplateToObject(obj, params);
+
+    expect(result).toEqual({
+      name: "agent",
+      config: {
+        timeout: "30",
+        labels: ["bug", "feature"],
+      },
+    });
+  });
+
+  test("should preserve non-string values", () => {
+    const obj = {
+      count: 5,
+      enabled: true,
+      name: "{{ parameters.name }}",
+    };
+    const params = { name: "test" };
+
+    const result = applyTemplateToObject(obj, params);
+
+    expect(result.count).toBe(5);
+    expect(result.enabled).toBe(true);
+    expect(result.name).toBe("test");
+  });
+});
+
+describe("validateParameters", () => {
+  const blueprint: BlueprintMetadata = {
+    name: "test",
+    version: "1.0.0",
+    parameters: [
+      { name: "required_string", type: "string", required: true },
+      { name: "optional_number", type: "number" },
+      { name: "with_default", type: "string", default: "default_value" },
+      { name: "enum_param", type: "enum", values: ["a", "b", "c"] },
+      { name: "array_param", type: "array" },
+      { name: "bool_param", type: "boolean" },
+    ],
+  };
+
+  test("should validate required parameters", () => {
+    const errors = validateParameters(blueprint, {});
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("parameters.required_string");
+    expect(errors[0].message).toContain("Required");
+  });
+
+  test("should accept valid parameter types", () => {
+    const errors = validateParameters(blueprint, {
+      required_string: "hello",
+      optional_number: 42,
+      enum_param: "b",
+      array_param: ["x", "y"],
+      bool_param: true,
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test("should reject invalid enum value", () => {
+    const errors = validateParameters(blueprint, {
+      required_string: "test",
+      enum_param: "invalid",
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("parameters.enum_param");
+    expect(errors[0].message).toContain("must be one of");
+  });
+
+  test("should reject wrong parameter types", () => {
+    const errors = validateParameters(blueprint, {
+      required_string: 123, // should be string
+      optional_number: "not a number", // should be number
+    });
+
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("should not require parameter with default", () => {
+    const errors = validateParameters(blueprint, {
+      required_string: "test",
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("mergeWithDefaults", () => {
+  const blueprint: BlueprintMetadata = {
+    name: "test",
+    version: "1.0.0",
+    parameters: [
+      { name: "with_default", type: "string", default: "default_value" },
+      { name: "no_default", type: "string" },
+      { name: "number_default", type: "number", default: 100 },
+    ],
+  };
+
+  test("should use provided values over defaults", () => {
+    const result = mergeWithDefaults(blueprint, {
+      with_default: "custom_value",
+    });
+
+    expect(result.with_default).toBe("custom_value");
+  });
+
+  test("should fill in defaults for missing values", () => {
+    const result = mergeWithDefaults(blueprint, {});
+
+    expect(result.with_default).toBe("default_value");
+    expect(result.number_default).toBe(100);
+    expect(result.no_default).toBeUndefined();
+  });
+});
+
+describe("resolveBlueprintSource", () => {
+  test("should resolve catalog source", () => {
+    const result = resolveBlueprintSource("catalog:standard-triage@v1");
+
+    expect(result.type).toBe("catalog");
+    expect(result.path).toBe("standard-triage");
+    expect(result.version).toBe("v1");
+  });
+
+  test("should resolve catalog source without version", () => {
+    const result = resolveBlueprintSource("catalog:my-blueprint");
+
+    expect(result.type).toBe("catalog");
+    expect(result.path).toBe("my-blueprint");
+    expect(result.version).toBe("latest");
+  });
+
+  test("should resolve GitHub source", () => {
+    const result = resolveBlueprintSource("github.com/org/repo/blueprints/triage.md@v2.0.0");
+
+    expect(result.type).toBe("github");
+    expect(result.path).toBe("org/repo/blueprints/triage.md");
+    expect(result.version).toBe("v2.0.0");
+  });
+
+  test("should resolve local relative path", () => {
+    const result = resolveBlueprintSource("./blueprints/triage.md");
+
+    expect(result.type).toBe("local");
+    expect(result.path).toBe("./blueprints/triage.md");
+  });
+
+  test("should resolve local path with base path", () => {
+    const result = resolveBlueprintSource("./triage.md", "/repo/.github/agents");
+
+    expect(result.type).toBe("local");
+    expect(result.path).toBe("/repo/.github/agents/triage.md");
+  });
+
+  test("should resolve absolute path", () => {
+    const result = resolveBlueprintSource("/absolute/path/blueprint.md");
+
+    expect(result.type).toBe("local");
+    expect(result.path).toBe("/absolute/path/blueprint.md");
+  });
+});
+
+describe("extendsBlueprint", () => {
+  test("should return true for frontmatter with extends", () => {
+    expect(extendsBlueprint({ extends: "./blueprint.md" })).toBe(true);
+  });
+
+  test("should return false for empty extends", () => {
+    expect(extendsBlueprint({ extends: "" })).toBe(false);
+  });
+
+  test("should return false for missing extends", () => {
+    expect(extendsBlueprint({ name: "agent" })).toBe(false);
+  });
+
+  test("should return false for non-string extends", () => {
+    expect(extendsBlueprint({ extends: 123 })).toBe(false);
+  });
+});
+
+describe("isBlueprint", () => {
+  test("should return true for frontmatter with blueprint object", () => {
+    expect(isBlueprint({ blueprint: { name: "test", version: "1.0.0" } })).toBe(true);
+  });
+
+  test("should return false for missing blueprint", () => {
+    expect(isBlueprint({ name: "agent" })).toBe(false);
+  });
+
+  test("should return false for null blueprint", () => {
+    expect(isBlueprint({ blueprint: null })).toBe(false);
+  });
+
+  test("should return false for non-object blueprint", () => {
+    expect(isBlueprint({ blueprint: "string" })).toBe(false);
+  });
+});

--- a/packages/parser/src/blueprint.ts
+++ b/packages/parser/src/blueprint.ts
@@ -1,0 +1,365 @@
+import { readFile } from "node:fs/promises";
+import type {
+  BlueprintDefinition,
+  BlueprintInstance,
+  BlueprintMetadata,
+  ValidationError,
+} from "@repo-agents/types";
+import matter from "gray-matter";
+import { z } from "zod";
+
+/**
+ * Schema for blueprint parameter definition
+ */
+const blueprintParameterSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  type: z.enum(["string", "number", "boolean", "array", "enum"]),
+  default: z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]).optional(),
+  required: z.boolean().optional(),
+  values: z.array(z.string()).optional(), // For enum type
+});
+
+/**
+ * Schema for blueprint metadata
+ */
+const blueprintMetadataSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "Version must be semver format (e.g., 1.0.0)"),
+  description: z.string().optional(),
+  author: z.string().optional(),
+  extends: z.string().optional(),
+  parameters: z.array(blueprintParameterSchema).default([]),
+});
+
+/**
+ * Schema for blueprint instance (agent that extends a blueprint)
+ */
+const blueprintInstanceSchema = z.object({
+  extends: z.string().min(1),
+  parameters: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]))
+    .optional(),
+});
+
+/**
+ * Parse a blueprint definition file.
+ */
+export async function parseBlueprint(filePath: string): Promise<{
+  blueprint?: BlueprintDefinition;
+  errors: ValidationError[];
+}> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf-8");
+  } catch (error) {
+    return {
+      errors: [
+        {
+          field: "file",
+          message: `Failed to read blueprint file: ${(error as Error).message}`,
+          severity: "error",
+        },
+      ],
+    };
+  }
+
+  return parseBlueprintContent(content);
+}
+
+/**
+ * Parse blueprint content (for testing and internal use).
+ */
+export function parseBlueprintContent(content: string): {
+  blueprint?: BlueprintDefinition;
+  errors: ValidationError[];
+} {
+  const errors: ValidationError[] = [];
+
+  // Parse frontmatter
+  let parsed: ReturnType<typeof matter>;
+  try {
+    parsed = matter(content);
+  } catch (error) {
+    return {
+      errors: [
+        {
+          field: "frontmatter",
+          message: `Failed to parse frontmatter: ${(error as Error).message}`,
+          severity: "error",
+        },
+      ],
+    };
+  }
+
+  // Check for blueprint metadata
+  if (!parsed.data || !parsed.data.blueprint) {
+    return {
+      errors: [
+        {
+          field: "blueprint",
+          message: "Blueprint metadata is required (blueprint: { name, version, ... })",
+          severity: "error",
+        },
+      ],
+    };
+  }
+
+  // Validate blueprint metadata
+  const metadataResult = blueprintMetadataSchema.safeParse(parsed.data.blueprint);
+  if (!metadataResult.success) {
+    return {
+      errors: metadataResult.error.issues.map((issue) => ({
+        field: `blueprint.${issue.path.join(".")}`,
+        message: issue.message,
+        severity: "error" as const,
+      })),
+    };
+  }
+
+  // Extract frontmatter template (everything except blueprint)
+  const { blueprint: _metadata, ...frontmatterTemplate } = parsed.data;
+
+  return {
+    blueprint: {
+      blueprint: metadataResult.data as BlueprintMetadata,
+      frontmatter: frontmatterTemplate,
+      markdown: parsed.content.trim(),
+    },
+    errors,
+  };
+}
+
+/**
+ * Parse an agent file that extends a blueprint.
+ */
+export function parseBlueprintInstance(frontmatter: Record<string, unknown>): {
+  instance?: BlueprintInstance;
+  errors: ValidationError[];
+} {
+  const result = blueprintInstanceSchema.safeParse(frontmatter);
+  if (!result.success) {
+    return {
+      errors: result.error.issues.map((issue) => ({
+        field: issue.path.join("."),
+        message: issue.message,
+        severity: "error" as const,
+      })),
+    };
+  }
+
+  return { instance: result.data, errors: [] };
+}
+
+/**
+ * Apply parameters to a template string.
+ * Supports {{ parameter_name }} syntax.
+ */
+export function applyTemplate(template: string, parameters: Record<string, unknown>): string {
+  return template.replace(/\{\{\s*parameters\.(\w+)\s*\}\}/g, (_match, paramName) => {
+    const value = parameters[paramName];
+    if (value === undefined) {
+      return `{{ parameters.${paramName} }}`; // Keep unresolved for error detection
+    }
+    if (Array.isArray(value)) {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  });
+}
+
+/**
+ * Apply parameters to a template object (recursively).
+ */
+export function applyTemplateToObject(
+  obj: Record<string, unknown>,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === "string") {
+      result[key] = applyTemplate(value, parameters);
+    } else if (Array.isArray(value)) {
+      result[key] = value.map((item) => {
+        if (typeof item === "string") {
+          return applyTemplate(item, parameters);
+        }
+        if (typeof item === "object" && item !== null) {
+          return applyTemplateToObject(item as Record<string, unknown>, parameters);
+        }
+        return item;
+      });
+    } else if (typeof value === "object" && value !== null) {
+      result[key] = applyTemplateToObject(value as Record<string, unknown>, parameters);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validate parameter values against blueprint definition.
+ */
+export function validateParameters(
+  blueprint: BlueprintMetadata,
+  providedParams: Record<string, unknown>,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  // Check required parameters
+  for (const param of blueprint.parameters) {
+    const value = providedParams[param.name];
+
+    if (param.required && value === undefined && param.default === undefined) {
+      errors.push({
+        field: `parameters.${param.name}`,
+        message: `Required parameter '${param.name}' is missing`,
+        severity: "error",
+      });
+      continue;
+    }
+
+    if (value === undefined) continue;
+
+    // Type validation
+    switch (param.type) {
+      case "string":
+        if (typeof value !== "string") {
+          errors.push({
+            field: `parameters.${param.name}`,
+            message: `Parameter '${param.name}' must be a string`,
+            severity: "error",
+          });
+        }
+        break;
+      case "number":
+        if (typeof value !== "number") {
+          errors.push({
+            field: `parameters.${param.name}`,
+            message: `Parameter '${param.name}' must be a number`,
+            severity: "error",
+          });
+        }
+        break;
+      case "boolean":
+        if (typeof value !== "boolean") {
+          errors.push({
+            field: `parameters.${param.name}`,
+            message: `Parameter '${param.name}' must be a boolean`,
+            severity: "error",
+          });
+        }
+        break;
+      case "array":
+        if (!Array.isArray(value)) {
+          errors.push({
+            field: `parameters.${param.name}`,
+            message: `Parameter '${param.name}' must be an array`,
+            severity: "error",
+          });
+        }
+        break;
+      case "enum":
+        if (!param.values?.includes(value as string)) {
+          errors.push({
+            field: `parameters.${param.name}`,
+            message: `Parameter '${param.name}' must be one of: ${param.values?.join(", ")}`,
+            severity: "error",
+          });
+        }
+        break;
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Merge parameter values with defaults.
+ */
+export function mergeWithDefaults(
+  blueprint: BlueprintMetadata,
+  providedParams: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+
+  for (const param of blueprint.parameters) {
+    if (providedParams[param.name] !== undefined) {
+      merged[param.name] = providedParams[param.name];
+    } else if (param.default !== undefined) {
+      merged[param.name] = param.default;
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Resolve a blueprint source string to a file path or URL.
+ * Supports:
+ * - Local paths: ./blueprints/my-blueprint.md
+ * - Catalog: catalog:standard-triage@v1
+ * - GitHub: github.com/org/repo/path@version
+ */
+export function resolveBlueprintSource(
+  source: string,
+  basePath?: string,
+): {
+  type: "local" | "catalog" | "github";
+  path: string;
+  version?: string;
+} {
+  // Catalog source
+  if (source.startsWith("catalog:")) {
+    const [name, version] = source.replace("catalog:", "").split("@");
+    return {
+      type: "catalog",
+      path: name,
+      version: version || "latest",
+    };
+  }
+
+  // GitHub source
+  if (source.startsWith("github.com/") || source.includes("github.com/")) {
+    const match = source.match(/github\.com\/([^@]+)(?:@(.+))?/);
+    if (match) {
+      return {
+        type: "github",
+        path: match[1],
+        version: match[2],
+      };
+    }
+  }
+
+  // Local path
+  if (source.startsWith("./") || source.startsWith("../") || source.startsWith("/")) {
+    const fullPath = basePath ? `${basePath}/${source.replace(/^\.\//, "")}` : source;
+    return {
+      type: "local",
+      path: fullPath,
+    };
+  }
+
+  // Default to local
+  return {
+    type: "local",
+    path: source,
+  };
+}
+
+/**
+ * Check if content looks like it extends a blueprint.
+ */
+export function extendsBlueprint(frontmatter: Record<string, unknown>): boolean {
+  return typeof frontmatter.extends === "string" && frontmatter.extends.length > 0;
+}
+
+/**
+ * Check if content is a blueprint definition.
+ */
+export function isBlueprint(frontmatter: Record<string, unknown>): boolean {
+  return typeof frontmatter.blueprint === "object" && frontmatter.blueprint !== null;
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -157,6 +157,19 @@ export class AgentParser {
 
 export const agentParser = new AgentParser();
 
+// Blueprint exports
+export {
+  applyTemplate,
+  applyTemplateToObject,
+  extendsBlueprint,
+  isBlueprint,
+  mergeWithDefaults,
+  parseBlueprint,
+  parseBlueprintContent,
+  parseBlueprintInstance,
+  resolveBlueprintSource,
+  validateParameters,
+} from "./blueprint";
 export type { AgentFrontmatter } from "./schemas";
 // Re-export schema types
 export { agentFrontmatterSchema } from "./schemas";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,44 @@ export interface AuditConfig {
   assignees?: string[]; // Assignees for audit issues
 }
 
+// Blueprint Types
+export type BlueprintParameterType = "string" | "number" | "boolean" | "array" | "enum";
+
+export interface BlueprintParameter {
+  name: string;
+  description?: string;
+  type: BlueprintParameterType;
+  default?: string | number | boolean | string[];
+  required?: boolean;
+  values?: string[]; // For enum type
+}
+
+export interface BlueprintMetadata {
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  extends?: string; // Parent blueprint to inherit from
+  parameters: BlueprintParameter[];
+}
+
+export interface BlueprintDefinition {
+  blueprint: BlueprintMetadata;
+  frontmatter: Record<string, unknown>; // Template frontmatter with {{ parameter }} placeholders
+  markdown: string; // Template markdown with {{ parameter }} placeholders
+}
+
+export interface BlueprintInstance {
+  extends: string; // Blueprint source (e.g., "catalog:standard-triage@v1", "./blueprints/custom.md")
+  parameters?: Record<string, string | number | boolean | string[]>; // Parameter values
+}
+
+export interface ResolvedBlueprint {
+  source: string;
+  metadata: BlueprintMetadata;
+  agent: AgentDefinition; // The resolved agent with parameters applied
+}
+
 export interface ConcurrencyConfig {
   group?: string; // Custom concurrency group (supports GitHub expressions)
   cancel_in_progress?: boolean; // Whether to cancel in-progress runs (default: true)


### PR DESCRIPTION
## Summary
- Adds blueprint types and interfaces to the types package
- Creates blueprint parsing module with frontmatter validation
- Implements template parameter substitution (`{{ parameters.name }}` syntax)
- Adds parameter validation with type checking (string, number, boolean, array, enum)
- Supports blueprint source resolution for local, catalog, and GitHub sources
- Exports all blueprint functions from the parser package

## Test plan
- [x] All 34 blueprint tests pass
- [x] Full test suite passes (957 tests)
- [x] Lint and typecheck pass

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)