### PR TITLE
Add Label Context guidance to Issue Quality agent

### DIFF
--- a/.github/agents/issue-quality.md
+++ b/.github/agents/issue-quality.md
@@ -151,6 +151,13 @@ When triggered by an edit, re-evaluate:
 - `needs-info` - Issue is missing critical information
 - `ready` - Issue is complete and ready for human review
 
+## Label Context
+
+- Read the repository's available labels (names + descriptions) from context before applying labels.
+- Use exact label names when they exist.
+- If an exact label doesn't exist, infer a synonym by matching description keywords (e.g., “needs-info” ↔ “needs more info”), and only apply labels that are confirmed present.
+- If no matching label exists, skip adding that label and mention the mismatch in your comment.
+
 **Labels you DON'T touch** (humans apply these):
 - `approved` - Human approved for implementation
 - `agent-assigned` - Assigned to implementation agent


### PR DESCRIPTION
### Motivation
- Ensure the Issue Quality agent reads the repository's available labels (names + descriptions) and only applies confirmed labels, inferring synonyms when appropriate and reporting mismatches in comments.

### Description
- Add a `Label Context` section to `.github/agents/issue-quality.md` that instructs the agent to read available labels, prefer exact matches, infer synonyms by matching description keywords (e.g., “needs-info” ↔ “needs more info”), skip labels that are not present, and keep the blocked labels `approved` and `agent-assigned` intact.

### Testing
- Documentation-only change to `.github/agents/issue-quality.md`, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a597a9b4832f9bdf2bc1b641dc4d)