### PR TITLE
Derive missing‑info questions from issue templates in Issue Quality agent

### DIFF
--- a/.github/agents/issue-quality.md
+++ b/.github/agents/issue-quality.md
@@ -97,19 +97,28 @@ When an issue comes in, immediately restructure it:
 
 ### Step 2: Identify Gaps
 
+Before checking for gaps, extract the required fields from the repository’s issue templates
+(`.github/ISSUE_TEMPLATE/*.yml`). Use the template that best matches the issue type and read
+the `validations.required: true` fields as required. Treat non-required fields as optional.
+
 After formatting, check what's missing:
 
 **For bugs:**
-- Can someone reproduce this from the steps given?
-- Is the expected vs actual behavior clear?
-- Is there enough environment info?
+- Compare the issue content against required fields from the bug template.
+- If required fields are discoverable, only ask for missing required fields first.
+- Ask optional fields only if they are essential to resolve the issue.
 
 **For features:**
-- Is the use case/problem clear?
-- Is the proposed solution specific enough to implement?
+- Compare the issue content against required fields from the feature template.
+- If required fields are discoverable, only ask for missing required fields first.
+- Ask optional fields only if they are essential to resolve the issue.
 
 **For questions:**
-- Is the question specific and answerable?
+- If required fields are discoverable, only ask for missing required fields first.
+- Ask optional fields only if they are essential to resolve the issue.
+
+**Fallback (if required fields aren’t discoverable):**
+- Use the existing checks (repro steps, expected vs actual, environment, clarity).
 
 ### Step 3: Ask for Missing Information OR Mark as Ready
 
@@ -117,6 +126,12 @@ After formatting, check what's missing:
 1. Add the `needs-info` label
 2. Comment with specific questions (not vague "more info please")
 3. Ask the reporter to edit the issue body with the answers
+
+When asking questions:
+- Ask only for missing required fields first.
+- Ask optional fields only if they are essential to resolve the issue.
+- If required fields aren’t discoverable, fall back to the existing checks (repro steps,
+  expected vs actual, environment).
 
 **Example:**
 ```


### PR DESCRIPTION
### Motivation
- Ensure the Issue Quality agent asks only for truly required information by extracting `validations.required: true` fields from the repository's issue templates and to avoid unnecessary or gatekeeping questions, with a fallback if required fields cannot be discovered.

### Description
- Update `.github/agents/issue-quality.md` to extract required fields from `.github/ISSUE_TEMPLATE/*.yml`, compare issue content against those required fields, ask for missing required fields first, ask optional fields only when essential, and fall back to existing repro/expected/environment checks if required fields aren’t discoverable.

### Testing
- No automated tests were run because this is a documentation/agent behavior change only; the change is limited to `.github/agents/issue-quality.md` and does not affect runtime code or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a929cda0832fa0657001f104e2ab)