### PR TITLE
Add issue template matching guidance to Issue Quality agent

### DIFF
--- a/.github/agents/issue-quality.md
+++ b/.github/agents/issue-quality.md
@@ -88,6 +88,13 @@ Reformat every issue into one of these templates:
 
 ## Workflow
 
+### Step 0: Check for Matching Templates
+
+Before formatting, scan available issue templates:
+- Enumerate available issue templates and their titles/keywords.
+- If a template matches the issue’s intent (e.g., “Incident”, “Proposal”), use that structure and avoid forcing the default bug/feature/question taxonomy.
+- If there’s no good match, fall back to the default templates.
+
 ### Step 1: Format the Issue
 
 When an issue comes in, immediately restructure it:


### PR DESCRIPTION
### Motivation
- Ensure the Issue Quality agent prefers existing repository issue templates when they match an issue's intent instead of forcing the default bug/feature/question taxonomy.

### Description
- Add `Step 0: Check for Matching Templates` to `.github/agents/issue-quality.md` that instructs the agent to enumerate available issue templates and their titles/keywords, use a matching template (e.g., “Incident”, “Proposal”) when appropriate, and fall back to the default templates if no good match exists.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a9281cec832fa98473b21bb9d637)