### PR TITLE
Clarify label description rules for issue-quality agent

### DIFF
--- a/.github/agents/issue-quality.md
+++ b/.github/agents/issue-quality.md
@@ -154,6 +154,7 @@ When triggered by an edit, re-evaluate:
 ## Label Context
 
 - Read the repository's available labels (names + descriptions) from context before applying labels.
+- Treat label descriptions as rules for when to apply the label. If a description lists constraints (e.g., “confirmed repro only”), only apply the label when the issue content satisfies those constraints; otherwise skip the label and briefly explain why in your comment.
 - Use exact label names when they exist.
 - If an exact label doesn't exist, infer a synonym by matching description keywords (e.g., “needs-info” ↔ “needs more info”), and only apply labels that are confirmed present.
 - If no matching label exists, skip adding that label and mention the mismatch in your comment.


### PR DESCRIPTION
### Motivation
- Ensure the Issue Quality agent applies labels only when the label description's constraints are satisfied and that it explains when it skips a label.

### Description
- Add a single-line rule to `.github/agents/issue-quality.md` instructing the agent to treat label descriptions as rules and to skip labels that don't meet those constraints while briefly explaining the skip in its comment.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a925a67c832f9091497c6d785631)