### PR TITLE
Prefer repo issue templates and label-awareness in Issue Quality agent

### DIFF
--- a/.github/agents/issue-quality.md
+++ b/.github/agents/issue-quality.md
@@ -33,7 +33,9 @@ You ensure issues are well-structured and contain all necessary information befo
 
 ## Issue Structure
 
-Reformat every issue into one of these templates:
+Before formatting, check whether the repository has issue templates. Look for issue templates in common locations (e.g., `.github/ISSUE_TEMPLATE/`, `.github/issue_template/`, or `ISSUE_TEMPLATE/`) and follow any template instructions that are available in the context. If templates are present, map the issue content into those sections and enforce required fields from the template. If no templates are present, fall back to the default templates below.
+
+Reformat every issue into one of these templates (fallback when templates are not available):
 
 ### Bug Report
 ```markdown
@@ -91,9 +93,11 @@ Reformat every issue into one of these templates:
 ### Step 1: Format the Issue
 
 When an issue comes in, immediately restructure it:
-- Choose the appropriate template (bug, feature, question)
+- Choose the appropriate template (bug, feature, question), preferring repository issue templates when they exist
 - Preserve ALL original content - reorganize, don't delete
 - Use `edit-issue` to update the body with the formatted version
+
+If you need to determine whether templates exist, inspect the repository tree or provided context rather than assuming. If the repo provides template guidance in comments or frontmatter, follow it.
 
 ### Step 2: Identify Gaps
 
@@ -148,8 +152,12 @@ When triggered by an edit, re-evaluate:
 
 ## Labels You Manage
 
-- `needs-info` - Issue is missing critical information
-- `ready` - Issue is complete and ready for human review
+Before applying labels, review the repository's available labels in the provided context. Use label names and descriptions to determine the best match. If the repo uses custom naming (e.g., different separators, prefixes, or synonyms), map intent based on descriptions rather than assuming fixed names.
+
+Use repository labels that exist in the current repo. Prefer exact label names when present, but you may infer the correct label name by matching label **descriptions** to intent (e.g., a label description that says "needs more info" should be treated as `needs-info`). Only apply labels that are confirmed to exist; if no matching label exists, skip adding it and explain in your comment.
+
+- `needs-info` - Issue is missing critical information (or the repo's equivalent label by description)
+- `ready` - Issue is complete and ready for human review (or the repo's equivalent label by description)
 
 **Labels you DON'T touch** (humans apply these):
 - `approved` - Human approved for implementation


### PR DESCRIPTION
### Motivation
- Make the Issue Quality agent repo-aware so it respects existing issue templates and label conventions instead of assuming fixed templates or label names.
- Reduce incorrect formatting and mislabeled issues by mapping to repository-provided templates and label descriptions when available.

### Description
- Updated `.github/agents/issue-quality.md` to first look for issue templates in common locations (e.g., `.github/ISSUE_TEMPLATE/`, `.github/issue_template/`, `ISSUE_TEMPLATE/`) and prefer those templates over the defaults.
- Added a fallback to the default templates when no repository templates are found and guidance to inspect repository tree or frontmatter for template guidance.
- Enhanced label-handling instructions so the agent reviews the repository's available labels and matches either exact names or label descriptions, and only applies labels confirmed to exist.
- Clarified mapping behavior for custom naming (separators, prefixes, synonyms) and explained what to do when no matching label exists.

### Testing
- Ran `bun run lint`, which failed because `bun` is not available in the environment and the `mise` config is not trusted (the linter could not run). 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a50f6680832f848c8be69bf6a998)